### PR TITLE
Fixed penalty

### DIFF
--- a/src/main/kotlin/no/uio/bedreflyt/lm/tasks/DecisionTask.kt
+++ b/src/main/kotlin/no/uio/bedreflyt/lm/tasks/DecisionTask.kt
@@ -72,7 +72,7 @@ class DecisionTask (
             roomInfos.add(RoomInfo(
                 roomNumber = office.roomNumber,
                 capacity = office.capacity,
-                penalty = office.monitoringCategory.description.toInt() // Assuming penalty is based on monitoring category
+                penalty = ward.officePenalty.toInt()
             ))
         }
 


### PR DESCRIPTION
This pull request updates the penalty calculation logic in the `DecisionTask` class to use a new property, `officePenalty`, from the `ward` object instead of deriving it from the `monitoringCategory` description.

Key change:

* [`src/main/kotlin/no/uio/bedreflyt/lm/tasks/DecisionTask.kt`]: Replaced the `penalty` assignment logic to use `ward.officePenalty.toInt()` instead of converting `office.monitoringCategory.description` to an integer. This simplifies and aligns the penalty calculation with the new data model.