### PR TITLE
Fix open room

### DIFF
--- a/src/main/kotlin/no/uio/bedreflyt/lm/service/TreatmentRoomService.kt
+++ b/src/main/kotlin/no/uio/bedreflyt/lm/service/TreatmentRoomService.kt
@@ -31,10 +31,13 @@ class TreatmentRoomService {
             }
     }
 
-    fun getWardCapacities (treatmentRooms: List<TreatmentRoom>) : Map<Ward, Int>{
+    fun getWardCapacities (treatmentRooms: List<TreatmentRoom>) : Map<Ward, Pair<Int, Int>>{
         return treatmentRooms.groupBy { it.treatmentWard }
             .mapValues { entry ->
-                entry.value.sumOf { it.capacity }
+                val totalCapacity = entry.value.sumOf { it.capacity }
+                val initialCapacity = entry.value.filter { it.monitoringCategory.description != "Korridor" && it.monitoringCategory.description != "Midlertidig" }
+                    .sumOf { it.capacity }
+                Pair(totalCapacity, initialCapacity)
             }
     }
 

--- a/src/main/kotlin/no/uio/bedreflyt/lm/tasks/DecisionTask.kt
+++ b/src/main/kotlin/no/uio/bedreflyt/lm/tasks/DecisionTask.kt
@@ -163,6 +163,10 @@ class DecisionTask (
         }
     }
 
+    private fun computeThreshold(completeCapacity: Double, threshold: Double): Int {
+        return (completeCapacity * threshold / 100).toInt()
+    }
+
     /**
      * Finds the appropriate room to open for incoming patients in a specific ward and hospital.
      *
@@ -203,9 +207,10 @@ class DecisionTask (
             log.info("Ward: $wardName, Hospital: $hospitalCode, Max Count: $count")
         }
         wardCapacities[currentWard]?.let {
-            val threshold = it - (it.toDouble() * currentWard.capacityThreshold / 100).toInt()
+            val threshold = computeThreshold(it.toDouble(), currentWard.capacityThreshold)
+            log.info("Threshold for ward $wardName in hospital $hospitalCode is $threshold and incoming patients are $incomingPatients")
             if (threshold > allocationCounts.getOrDefault(Pair(wardName, hospitalCode), 0) + incomingPatients) {
-                log.warning("Ward $wardName in hospital $hospitalCode below threshold")
+                log.info("Ward $wardName in hospital $hospitalCode below threshold")
                 removeOpenedCorridorsOffice(treatmentRooms, wardName, hospitalCode, simulation)
                 return true
             }
@@ -219,7 +224,7 @@ class DecisionTask (
         )
 
         val currentCapacity = wardCapacities.values.firstOrNull() ?: 0
-        val freeCapacity = currentCapacity - allocationCounts.getOrDefault(Pair(wardName, hospitalCode), 0)
+        val freeCapacity = computeThreshold(currentCapacity.toDouble(), currentWard.capacityThreshold) - allocationCounts.getOrDefault(Pair(wardName, hospitalCode), 0)
         val request = RoomRequest (
             currentFreeCapacity = freeCapacity,
             incomingPatients = incomingPatients,


### PR DESCRIPTION
This pull request introduces enhancements to the capacity management logic in the `TreatmentRoomService` and `DecisionTask` classes. The changes focus on distinguishing between total and initial capacities for wards, improving threshold calculations, and refining decision-making for room allocations.

### Capacity Management Enhancements:

* **Updated `getWardCapacities` Method**: Modified the `getWardCapacities` method in `TreatmentRoomService` to return a `Map` where each ward's capacity is represented as a `Pair` of total capacity and initial capacity. Initial capacity excludes rooms categorized as "Korridor" or "Midlertidig". (`src/main/kotlin/no/uio/bedreflyt/lm/service/TreatmentRoomService.kt`)

* **Threshold Calculation Utility**: Added a new private method `computeThreshold` in `DecisionTask` to standardize the calculation of thresholds based on capacity and a percentage. (`src/main/kotlin/no/uio/bedreflyt/lm/tasks/DecisionTask.kt`)

### Decision-Making Improvements:

* **Enhanced Threshold Logic**: Updated decision logic in `DecisionTask` to use both initial and total capacities for threshold checks. This ensures more precise decisions when determining whether to open rooms for incoming patients. (`src/main/kotlin/no/uio/bedreflyt/lm/tasks/DecisionTask.kt`)

* **Refined Free Capacity Calculation**: Adjusted the calculation of free capacity to incorporate the new `computeThreshold` method, aligning it with the updated capacity representation. (`src/main/kotlin/no/uio/bedreflyt/lm/tasks/DecisionTask.kt`)

* **Consistent Capacity Representation**: Updated all references to `wardCapacities` in `DecisionTask` to use the new `Pair<Int, Int>` structure, ensuring consistency across the class. (`src/main/kotlin/no/uio/bedreflyt/lm/tasks/DecisionTask.kt`)