### PR TITLE
Enhance docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,28 @@
-# Use an official OpenJDK runtime as a parent image
-FROM openjdk:24-oraclelinux8
+# Build stage
+FROM gradle:8.5-jdk21 AS build
+
+# Set the working directory
+WORKDIR /app
+
+# Copy gradle files
+COPY build.gradle settings.gradle gradle.properties ./
+COPY gradle ./gradle
+
+# Copy source code
+COPY src ./src
+
+# Build the application
+RUN gradle bootJar --no-daemon && \
+    rm -f /app/build/libs/*-plain.jar
+
+# Runtime stage
+FROM openjdk:24-ea-oraclelinux8
 
 # Set the working directory in the container
 WORKDIR /app
 
-# Copy the executable jar file to the container
-COPY bedreflyt-lm.jar /app/bedreflyt-lm.jar
+# Copy the executable jar file from build stage
+COPY --from=build /app/build/libs/bedreflyt-lm-*.jar /app/bedreflyt-lm.jar
 
 # Expose the port that the application will run on
 EXPOSE 8091

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'no.uio'
-version = '0.2.0'
+version = '0.2.1'
 base {
     archivesName = 'bedreflyt-lm'
 }


### PR DESCRIPTION
This pull request updates the `Dockerfile` to use a multi-stage build process, which improves the Docker image by separating the build and runtime environments. This results in smaller, more secure, and more maintainable images.

Dockerfile improvements:

* Switched to a multi-stage build: The Dockerfile now uses a `gradle:8.5-jdk21` image for building the application and an `openjdk:24-ea-oraclelinux8` image for running it, reducing the final image size and attack surface.
* Added steps to copy Gradle configuration and source files, build the JAR using `bootJar`, and remove unnecessary artifacts from the build stage.
* Modified the runtime stage to copy the built JAR from the build stage instead of relying on a pre-built artifact.